### PR TITLE
Change standard output to stderr

### DIFF
--- a/code/LeakSani.cpp
+++ b/code/LeakSani.cpp
@@ -24,6 +24,7 @@
 #include "signalHandlers.hpp"
 #include "bytePrinter.hpp"
 #include "../include/lsan_stats.h"
+#include "../include/lsan_internals.h"
 
 bool __lsan_printStatsOnExit = false;
 
@@ -124,9 +125,15 @@ size_t LSan::getTotalAllocatedBytes() {
 
 void LSan::__exit_hook() {
     setIgnoreMalloc(true);
-    std::cout << std::endl
-              << "\033[32mExiting\033[39m" << std::endl << std::endl
-              << getInstance() << std::endl;
+	if (__lsan_printCout) {
+        std::cout << std::endl
+                  << "\033[32mExiting\033[39m" << std::endl << std::endl
+                  << getInstance() << std::endl;
+	} else {
+		std::cerr << std::endl
+				  << "\033[32mExiting\033[39m" << std::endl << std::endl
+				  << getInstance() << std::endl;
+	}
     if (__lsan_printStatsOnExit) {
         __lsan_printStats();
     }

--- a/code/lsan_internals.cpp
+++ b/code/lsan_internals.cpp
@@ -20,6 +20,7 @@
 #include "../include/lsan_internals.h"
 
 bool __lsan_humanPrint   = true;
+bool __lsan_printCout    = false;
 
 bool __lsan_invalidCrash = true;
 bool __lsan_invalidFree  = false;

--- a/code/wrap_malloc.cpp
+++ b/code/wrap_malloc.cpp
@@ -109,9 +109,15 @@ void __wrap_free(void * pointer, const char * file, int line) {
 
 [[ noreturn ]] void __wrap_exit(int code, const char * file, int line) {
     LSan::setIgnoreMalloc(true);
-    std::cout << std::endl
-              << "\033[32mExiting\033[39m at \033[4m" << file << ":" << line << "\033[24m" << std::endl << std::endl
-              << LSan::getInstance() << std::endl;
+	if (__lsan_printCout) {
+        std::cout << std::endl
+                  << "\033[32mExiting\033[39m at \033[4m" << file << ":" << line << "\033[24m" << std::endl << std::endl
+                  << LSan::getInstance() << std::endl;
+	} else {
+		std::cout << std::endl
+				  << "\033[32mExiting\033[39m at \033[4m" << file << ":" << line << "\033[24m" << std::endl << std::endl
+				  << LSan::getInstance() << std::endl;
+	}
     if (__lsan_printStatsOnExit) {
         __lsan_printStats();
     }

--- a/include/lsan_internals.h
+++ b/include/lsan_internals.h
@@ -27,6 +27,7 @@ extern "C" {
 #include <stdbool.h>
 
 extern bool __lsan_humanPrint;
+extern bool __lsan_printCout;
 
 extern bool __lsan_invalidCrash;
 extern bool __lsan_invalidFree;


### PR DESCRIPTION
output can be redirected to stdout by setting the extern bool `_lsan_printCout` to `true`, standard is `false`.
Future suggestion: set the output to another fd with an extern variable.